### PR TITLE
fix: adjust button outline offset

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -80,6 +80,7 @@ select:focus {
   appearance: none;
   border: 0;
   cursor: pointer;
+  outline-offset: -3px;
 
   background: var(--dk-button-color);
   color: #fff;


### PR DESCRIPTION
Button outline will be cut off with default offset

-  Before:
![image](https://github.com/user-attachments/assets/1e27b452-df32-4d49-ba97-265a7d726155)
![image](https://github.com/user-attachments/assets/5fed3a47-3e6e-42ad-b326-d1d47323f4f2)

-  After:
![image](https://github.com/user-attachments/assets/c62d5177-874a-4dfb-9ef3-4246ee3310ea)
![image](https://github.com/user-attachments/assets/20004e5e-e1e0-4080-af74-25d2048121e6)