### PR TITLE
app: skip language selection if language is chosen at boot menu

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -742,6 +742,13 @@ fn is_offline_install() -> bool {
     is_local_recipe()
 }
 
+#[tauri::command]
+/// Skip the language selection menu if LANG is set from the boot menu.
+/// LANG will be C.UTF-8 if not chosen at boot.
+async fn is_lang_already_set() -> bool {
+    env::var("LANG").is_ok_and(|x| x != "C.UTF-8")
+}
+
 fn set_locale_inner(locale: &str) -> io::Result<()> {
     Command::new("localectl")
         .arg("set-locale")
@@ -893,6 +900,7 @@ pub async fn run() {
                     get_arch_name,
                     is_lvm_device,
                     read_locale,
+                    is_lang_already_set,
                     is_offline_install,
                 ])
                 .run(tauri::generate_context!())

--- a/src/views/LangSelect.vue
+++ b/src/views/LangSelect.vue
@@ -32,7 +32,8 @@ export default defineComponent({
   },
   async mounted() {
     const isInstall = await invoke('is_skip');
-    if (isInstall) {
+    const isLangSet = await invoke('is_lang_already_set') as boolean;
+    if (isInstall || isLangSet) {
       this.loading = true;
       const lang = await invoke('read_locale');
       const locale = this.langData.find((v) => v.locale === lang);


### PR DESCRIPTION
LANG will be set during initrd, according to the selection from GRUB menu. If somehow it is not chosen, the default fallback C.UTF-8 will be applied to the live environment.